### PR TITLE
change default return value to -1 if no value has been recorded

### DIFF
--- a/domain/src/main/java/com/edu/uni/augsburg/uniatron/domain/dao/SummaryDao.java
+++ b/domain/src/main/java/com/edu/uni/augsburg/uniatron/domain/dao/SummaryDao.java
@@ -31,7 +31,7 @@ public interface SummaryDao {
             + "TOTAL(step_count) as 'mSteps', "
             + "(SELECT TOTAL(usage_time_in_seconds) FROM AppUsageEntity "
             + "WHERE date(timestamp/1000, 'unixepoch') = date(sce.timestamp/1000, 'unixepoch')) "
-            + "as 'mAppUsageTime', (SELECT CASE WHEN AVG(value) IS NULL THEN 0.0 ELSE AVG(value) END "
+            + "as 'mAppUsageTime', (SELECT CASE WHEN AVG(value) IS NULL THEN -1.0 ELSE AVG(value) END "
             + "FROM EmotionEntity WHERE date(timestamp/1000, 'unixepoch') = "
             + "date(sce.timestamp/1000, 'unixepoch')) as 'mEmotionAvg' "
             + "FROM StepCountEntity sce "


### PR DESCRIPTION
#### Short description of what this resolves:
issue #39 

#### Changes proposed in this pull request:
- default value that the summaryDao returns for emotions is -1 if there hasn't been an emotion set for the day

#### Does this close any currently open issues?
#39 
